### PR TITLE
Add rebuild mode for new-post script

### DIFF
--- a/workflows/deploy.yml
+++ b/workflows/deploy.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # （任意）Markdown→HTML を CI で再生成したい場合だけ有効化。
-      # 運用メモの想定では node scripts/new-post.mjs --rebuild を叩く設計です。
+      # （任意）posts.json / posts.js を既存データから CI で再生成したい場合だけ有効化。
+      # Markdown→HTML の再生成が必要なら scripts/new-post.mjs --rebuild 内で処理してください。
       # スクリプトがないならこの2ステップは消してOK。
       - name: Setup Node
         if: hashFiles('scripts/new-post.mjs') != ''


### PR DESCRIPTION
## Summary
- add a --rebuild mode to scripts/new-post.mjs that regenerates posts metadata and updates the usage text
- share the sorting logic between new and rebuild flows and validate the rebuild option arguments
- adjust the deploy workflow comments to describe the rebuild step

## Testing
- node scripts/new-post.mjs --rebuild

------
https://chatgpt.com/codex/tasks/task_e_68d0c2bc4e50832a9d94f6e83722d91e