### PR TITLE
Fix sample note document title

### DIFF
--- a/notes/sample.html
+++ b/notes/sample.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title> — synomare Notes</title>
+  <title>タグ対応テスト — synomare Notes</title>
   <meta name="description" content="ここに記事の概要を1〜2文で書いてください。">
   <meta property="og:title" content="タグ対応テスト — synomare Notes">
   <meta property="og:description" content="ここに記事の概要を1〜2文で書いてください。">


### PR DESCRIPTION
## Summary
- update the sample note's `<title>` so it matches the article and OG metadata

## Testing
- Verified in a headless browser that the tab title renders as "タグ対応テスト — synomare Notes"

------
https://chatgpt.com/codex/tasks/task_e_68d0c2bfcce4832aa76e46056bbaa9a9