### PR TITLE
Ensure notes sorting is stable for identical dates

### DIFF
--- a/notes/hello.html
+++ b/notes/hello.html
@@ -111,7 +111,12 @@
         nav.appendChild(back);
         return;
       }
-      posts.sort(function(a,b){return a.date<b.date?1:-1});
+      posts.sort(function(a,b){
+        if(a.date===b.date) return 0;
+        if(!a.date) return 1;
+        if(!b.date) return -1;
+        return a.date<b.date?1:-1;
+      });
       var backLink=document.createElement('a');
       backLink.href='index.html';
       backLink.textContent='一覧へ戻る';

--- a/notes/index.html
+++ b/notes/index.html
@@ -109,7 +109,12 @@
         list.appendChild(empty);
         return;
       }
-      posts.sort(function(a,b){return a.date<b.date?1:-1});
+      posts.sort(function(a,b){
+        if(a.date===b.date) return 0;
+        if(!a.date) return 1;
+        if(!b.date) return -1;
+        return a.date<b.date?1:-1;
+      });
       posts.forEach(function(post){
         var li=document.createElement('li');
         var link=document.createElement('a');

--- a/notes/post-template.html
+++ b/notes/post-template.html
@@ -110,7 +110,12 @@
         nav.appendChild(back);
         return;
       }
-      posts.sort(function(a,b){return a.date<b.date?1:-1});
+      posts.sort(function(a,b){
+        if(a.date===b.date) return 0;
+        if(!a.date) return 1;
+        if(!b.date) return -1;
+        return a.date<b.date?1:-1;
+      });
       var backLink=document.createElement('a');
       backLink.href='index.html';
       backLink.textContent='一覧へ戻る';

--- a/notes/sample.html
+++ b/notes/sample.html
@@ -112,7 +112,12 @@
         nav.appendChild(back);
         return;
       }
-      posts.sort(function(a,b){return a.date<b.date?1:-1});
+      posts.sort(function(a,b){
+        if(a.date===b.date) return 0;
+        if(!a.date) return 1;
+        if(!b.date) return -1;
+        return a.date<b.date?1:-1;
+      });
       var backLink=document.createElement('a');
       backLink.href='index.html';
       backLink.textContent='一覧へ戻る';


### PR DESCRIPTION
## Summary
- ensure the notes index uses a comparator that returns 0 when dates match so same-day posts keep their defined order
- apply the same stable comparator to the per-post navigation (template and existing posts) so the list and navigation stay aligned

## Testing
- browser_container.run_playwright_script (confirm index list and navigation order with same-day posts)


------
https://chatgpt.com/codex/tasks/task_e_68d0c2bebcac832ab230bc14768a4920