### PR TITLE
Upgrade upload artifact action in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,8 +33,9 @@ jobs:
         uses: actions/configure-pages@v4
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
+          name: github-pages
           path: .
 
   deploy:


### PR DESCRIPTION
## Summary
- update the GitHub Pages deploy workflow to use the latest `actions/upload-artifact`

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d0f6e6f3f0832abc12a3f6eb6a7c38