### PR TITLE
Fix notes post sorting without conflict markers

### DIFF
--- a/notes/index.html
+++ b/notes/index.html
@@ -109,16 +109,14 @@
         list.appendChild(empty);
         return;
       }
-<<<<<<< HEAD
       posts.sort(function(a,b){
-        if(a.date===b.date) return 0;
-        if(!a.date) return 1;
-        if(!b.date) return -1;
-        return a.date<b.date?1:-1;
+        var timeA=a&&a.date?Date.parse(a.date):NaN;
+        var timeB=b&&b.date?Date.parse(b.date):NaN;
+        if(timeA===timeB) return 0;
+        if(isNaN(timeA)) return 1;
+        if(isNaN(timeB)) return -1;
+        return timeA<timeB?1:-1;
       });
-=======
-      posts.sort(function(a,b){return a.date<b.date?1:-1});
->>>>>>> 75ff897 (Initial commit)
       posts.forEach(function(post){
         var li=document.createElement('li');
         var link=document.createElement('a');

--- a/notes/post-template.html
+++ b/notes/post-template.html
@@ -110,16 +110,14 @@
         nav.appendChild(back);
         return;
       }
-<<<<<<< HEAD
       posts.sort(function(a,b){
-        if(a.date===b.date) return 0;
-        if(!a.date) return 1;
-        if(!b.date) return -1;
-        return a.date<b.date?1:-1;
+        var timeA=a&&a.date?Date.parse(a.date):NaN;
+        var timeB=b&&b.date?Date.parse(b.date):NaN;
+        if(timeA===timeB) return 0;
+        if(isNaN(timeA)) return 1;
+        if(isNaN(timeB)) return -1;
+        return timeA<timeB?1:-1;
       });
-=======
-      posts.sort(function(a,b){return a.date<b.date?1:-1});
->>>>>>> 75ff897 (Initial commit)
       var backLink=document.createElement('a');
       backLink.href='index.html';
       backLink.textContent='一覧へ戻る';


### PR DESCRIPTION
## Summary
- remove the leftover merge conflict markers from the notes list and post template
- ensure posts are sorted in descending order while tolerating missing or invalid dates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2e5dc0018832aaab1a02e44f41920