### PR TITLE
Allow touch scrolling and selection in the copy block

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
     .menu a + a{border-top:1px solid var(--menu-divider)}
     .menu a:hover{background: color-mix(in oklch, var(--menu-bg) 82%, var(--menu-fg))}
     main{display:grid; place-items:center; padding:clamp(24px,6vw,80px)}
-    .copy{max-width:var(--maxw); font-size:var(--dynamic-font-size, clamp(26px,6.8vw,56px)); line-height:1.10; letter-spacing:-0.03em; font-kerning:normal; font-variant-east-asian:proportional-width; font-feature-settings:"palt" 1, "kern" 1; text-rendering:optimizeLegibility; line-break:strict; hanging-punctuation:allow-end; touch-action:none; overscroll-behavior:contain}
+    .copy{max-width:var(--maxw); font-size:var(--dynamic-font-size, clamp(26px,6.8vw,56px)); line-height:1.10; letter-spacing:-0.03em; font-kerning:normal; font-variant-east-asian:proportional-width; font-feature-settings:"palt" 1, "kern" 1; text-rendering:optimizeLegibility; line-break:strict; hanging-punctuation:allow-end; touch-action:pan-y}
     .copy p{margin:0 0 .55em}
     .copy.tight{ line-height:1.03; letter-spacing:-0.055em }
     .copy .c{ display:inline-block; --ix:1; --iy:1; transform: translateX(var(--tx,0)) translateY(var(--ty,0)) scale(var(--sx,1), var(--sy,1)) scale(var(--ix,1), var(--iy,1)); transform-origin:50% 75%; will-change: transform; transition:transform .28s cubic-bezier(.25,.82,.25,1) }
@@ -341,6 +341,9 @@
       var raf=null;
       var activePointerId=null;
       var pointer={x:0,y:0,targetX:0,targetY:0,strength:0,active:false};
+      var touchGesture={pointerId:null,startX:0,startY:0,interaction:null,hasCapture:false,activationTimer:null};
+      var TOUCH_SCROLL_THRESHOLD=12;
+      var TOUCH_RELEASE_DISTANCE=18;
 
       function measure(){
         metrics=letters.map(function(el){
@@ -480,10 +483,44 @@
         if(activePointerId!==null && e.pointerId!==activePointerId && e.pointerType!=='mouse') return;
         updatePointerFromEvent(e);
         if(e.pointerType==='touch'){
-          if(e.isPrimary && typeof copy.setPointerCapture==='function'){
-            try{ copy.setPointerCapture(e.pointerId); }catch(err){}
+          if(touchGesture.pointerId===null){
+            touchGesture.pointerId=e.pointerId;
+            touchGesture.startX=e.clientX;
+            touchGesture.startY=e.clientY;
           }
-          if(e.cancelable) e.preventDefault();
+          if(touchGesture.pointerId===e.pointerId && touchGesture.interaction!=='native'){
+            var dx=e.clientX-touchGesture.startX;
+            var dy=e.clientY-touchGesture.startY;
+            var absX=Math.abs(dx);
+            var absY=Math.abs(dy);
+            var distance=Math.sqrt(dx*dx+dy*dy);
+            var verticalDominant=absY>absX && absY>6;
+            if((verticalDominant && absY>TOUCH_SCROLL_THRESHOLD) || distance>TOUCH_RELEASE_DISTANCE){
+              touchGesture.interaction='native';
+              if(touchGesture.activationTimer){
+                clearTimeout(touchGesture.activationTimer);
+                touchGesture.activationTimer=null;
+              }
+              if(touchGesture.hasCapture && typeof copy.releasePointerCapture==='function'){
+                try{ copy.releasePointerCapture(e.pointerId); }catch(err){}
+                touchGesture.hasCapture=false;
+              }
+              if(activePointerId===e.pointerId) activePointerId=null;
+              pointer.active=false;
+              schedule();
+              return;
+            }
+          }
+          if(touchGesture.interaction==='pending'){
+            schedule();
+            return;
+          }
+          if(touchGesture.interaction==='lens'){
+            if(!touchGesture.hasCapture && typeof copy.setPointerCapture==='function'){
+              try{ copy.setPointerCapture(e.pointerId); touchGesture.hasCapture=true; }catch(err){}
+            }
+            if(e.cancelable) e.preventDefault();
+          }
         }else if(e.pointerType==='mouse'){
           pointer.active=true;
         }
@@ -495,10 +532,21 @@
         updatePointerFromEvent(e);
         pointer.active=true;
         if(e.pointerType==='touch'){
-          if(typeof copy.setPointerCapture==='function'){
-            try{ copy.setPointerCapture(e.pointerId); }catch(err){}
+          touchGesture.pointerId=e.pointerId;
+          touchGesture.startX=e.clientX;
+          touchGesture.startY=e.clientY;
+          touchGesture.interaction='pending';
+          touchGesture.hasCapture=false;
+          if(touchGesture.activationTimer){
+            clearTimeout(touchGesture.activationTimer);
           }
-          if(e.cancelable) e.preventDefault();
+          var pid=e.pointerId;
+          touchGesture.activationTimer=setTimeout(function(){
+            if(touchGesture.pointerId===pid && touchGesture.interaction==='pending'){
+              touchGesture.interaction='lens';
+            }
+            touchGesture.activationTimer=null;
+          },60);
         }
         schedule();
       },{passive:false});
@@ -506,8 +554,17 @@
       function handlePointerEnd(e){
         if(activePointerId!==null && e.pointerId!==activePointerId && e.pointerType!=='mouse') return;
         if(e.pointerId===activePointerId) activePointerId=null;
-        if(e.pointerType==='touch' && typeof copy.releasePointerCapture==='function'){
-          try{ copy.releasePointerCapture(e.pointerId); }catch(err){}
+        if(e.pointerType==='touch'){
+          if(touchGesture.activationTimer){
+            clearTimeout(touchGesture.activationTimer);
+            touchGesture.activationTimer=null;
+          }
+          if(typeof copy.releasePointerCapture==='function'){
+            try{ copy.releasePointerCapture(e.pointerId); }catch(err){}
+          }
+          touchGesture.hasCapture=false;
+          if(touchGesture.pointerId===e.pointerId) touchGesture.pointerId=null;
+          touchGesture.interaction=null;
         }
         pointer.active=false;
         schedule();


### PR DESCRIPTION
## Summary
- allow the `.copy` container to permit vertical touch gestures instead of blocking default behavior
- add touch gesture state to the pointer handlers so lens interactions only capture and cancel touches while the finger stays mostly stationary

## Testing
- not run (touch emulator unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d2e903e638832aba4447383cfbcd5f